### PR TITLE
Fix documentation autogen

### DIFF
--- a/example.asd
+++ b/example.asd
@@ -1,7 +1,8 @@
 (defsystem "example" 
-  :class :package-inferred-system
   :author "Alexander Artemenko"
   :license "Unlicense"
   :pathname "src"
   :description "This description will be used only if long-description is missing"
-  :depends-on ("example/app"))
+  :serial t
+  :components ((:file "utils")
+               (:file "app")))


### PR DESCRIPTION
The sources must be recompiled before auto-generated documentation can be inserted, ergo you can generate documentation only for one particular system, not for dependencies.